### PR TITLE
Use single guillemets for previous/next page

### DIFF
--- a/src/internal.js
+++ b/src/internal.js
@@ -459,7 +459,7 @@ function renderPagination()
 
             renderPaginationItem.call(this, pagination, "first", "&laquo;", "first")
                 ._bgEnableAria(current > 1);
-            renderPaginationItem.call(this, pagination, "prev", "&lt;", "prev")
+            renderPaginationItem.call(this, pagination, "prev", "&lsaquo;", "prev")
                 ._bgEnableAria(current > 1);
 
             for (var i = 0; i < count; i++)
@@ -475,7 +475,7 @@ function renderPagination()
                     ._bgEnableAria(false)._bgSelectAria();
             }
 
-            renderPaginationItem.call(this, pagination, "next", "&gt;", "next")
+            renderPaginationItem.call(this, pagination, "next", "&rsaquo;", "next")
                 ._bgEnableAria(totalPages > current);
             renderPaginationItem.call(this, pagination, "last", "&raquo;", "last")
                 ._bgEnableAria(totalPages > current);


### PR DESCRIPTION
Currently, pagination uses double guillemets for first/last page and lower than/greater than signs for previous next (like so: `« < 1 2 3 > »`). This looks ugly. Change this to use single guillemets, for visual consistency (like so: `« ‹ 1 2 3 › »`).