### PR TITLE
converters / datetime - fix object check

### DIFF
--- a/src/public.js
+++ b/src/public.js
@@ -264,7 +264,7 @@ Grid.defaults = {
               return value ? moment(parseInt(value)*1000) : "";
            },
            to: function (value) {
-              if (!Object.is(value)) {
+              if (!moment.isMoment(value)) {
                  value = moment(parseInt(value)*1000);
               }
               return value ? value.format("lll") : "";


### PR DESCRIPTION
Object.is() checks equality between two parameters, not whether the variable is an object, better to use the built-in moment method for this.